### PR TITLE
v2.2.3: Support Sidekiq 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.2.3
+
+- Bump Sidekiq dependency to version 7
+
 ## 2.2.2
 
 - Allow configuration option `require_confirm_prompt_message` to accept a Proc or Ruby callable object.

--- a/lib/sidekiq_adhoc_job/version.rb
+++ b/lib/sidekiq_adhoc_job/version.rb
@@ -1,3 +1,3 @@
 module SidekiqAdhocJob
-  VERSION = '2.2.2'.freeze
+  VERSION = '2.2.3'.freeze
 end

--- a/sidekiq_adhoc_job.gemspec
+++ b/sidekiq_adhoc_job.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test', '~> 1.1.0'
   spec.add_development_dependency 'mock_redis', '~> 0.26.0'
 
-  spec.add_runtime_dependency 'sidekiq', '< 7'
+  spec.add_runtime_dependency 'sidekiq', '< 8'
 end


### PR DESCRIPTION
Actual fix is from https://github.com/gohkhoonhiang/sidekiq_adhoc_job/pull/34 thanks to @gohdaniel15

This allows applications using sidekiq_adhoc_job to upgrade to Sidekiq 7