### PR TITLE
[Dev Fix] [EE] Remove in-line JavaScript [LOYAL-10445]

### DIFF
--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -38,9 +38,9 @@ module SidekiqAdhocJob
     assets_path = File.expand_path('sidekiq_adhoc_job/web/assets', __dir__)
 
     Sidekiq::Web.use Rack::Static, urls: ['/javascript'],
-                               root: assets_path,
-                               cascade: true,
-                               header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]
+                                   root: assets_path,
+                                   cascade: true,
+                                   header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]
 
   end
 

--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -34,6 +34,14 @@ module SidekiqAdhocJob
     Sidekiq::Web.register(SidekiqAdhocJob::Web)
     Sidekiq::Web.tabs['adhoc_jobs'] = 'adhoc-jobs'
     Sidekiq::Web.locales << File.expand_path('sidekiq_adhoc_job/web/locales', __dir__)
+
+    assets_path = File.expand_path('sidekiq_adhoc_job/web/assets', __dir__)
+
+    Sidekiq::Web.use Rack::Static, urls: ['/javascript'],
+                               root: assets_path,
+                               cascade: true,
+                               header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]
+
   end
 
   def self.strategies

--- a/lib/sidekiq_adhoc_job/web/assets/javascript/require_confirm.js
+++ b/lib/sidekiq_adhoc_job/web/assets/javascript/require_confirm.js
@@ -1,0 +1,11 @@
+
+document.getElementById('adhoc-jobs-submit-form').addEventListener('submit', (event) => {
+  const confirmPrompt = document.getElementById('presented-job').getAttribute('data-confirm-prompt');
+  const input = prompt(`Please enter "${confirmPrompt}" to confirm`);
+  if (input !== confirmPrompt) {
+    event.preventDefault();
+    if (input !== null) {
+      alert('Your confirmation input is incorrect, try again.');
+    }
+  }
+})

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -57,16 +57,8 @@
 </form>
 
 <% if @presented_job.require_confirm %>
-  <script>
-    document.getElementById('adhoc-jobs-submit-form').addEventListener('submit', (event) => {
-      const confirmPrompt = "<%= @presented_job.confirm_prompt_message %>";
-      const input = prompt(`Please enter "${confirmPrompt}" to confirm`);
-      if (input !== confirmPrompt) {
-        event.preventDefault();
-        if (input !== null) {
-          alert('Your confirmation input is incorrect, try again.');
-        }
-      }
-    })
+  <div id="presented-job" data-confirm-prompt="<%= @presented_job.confirm_prompt_message %>">
+  </div>
+  <script type="text/javascript" src="<%= root_path %>javascript/require_confirm.js">
   </script>
 <% end %>


### PR DESCRIPTION
https://kaligo.atlassian.net/browse/LOYAL-10445

# Background
- After updating SideKiq to 7.2 onwards, in-line javascript in .erb files is no longer allowed.

- This affects SideKiq Adhoc Job, causing scripts such as requiring confirmation before running a job to not be executed.

# Design
- Fix by moving javascript into separate script files.
- [Example of how to fix](https://github.com/kenaniah/sidekiq-status/pull/44/files)

# Testing
- Ensure confirmation alert before running a job appears.
- Ensure specs pass.