### PR TITLE
[Dev Fix] [EE] Add JavaScript to check Opt Params [LOYAL-10414]

### DIFF
--- a/lib/sidekiq_adhoc_job.rb
+++ b/lib/sidekiq_adhoc_job.rb
@@ -38,11 +38,11 @@ module SidekiqAdhocJob
     assets_path = File.expand_path('sidekiq_adhoc_job/web/assets', __dir__)
 
     Sidekiq::Web.use Rack::Static, urls: ['/javascript'],
-                               root: assets_path,
-                               cascade: true,
-                               header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]
+                                   root: assets_path,
+                                   cascade: true,
+                                   header_rules: [[:all, { 'cache-control' => 'private, max-age=86400' }]]
 
-  end
+end
 
   def self.strategies
     @_strategies ||= []

--- a/lib/sidekiq_adhoc_job/web/assets/javascript/check_opt_params.js
+++ b/lib/sidekiq_adhoc_job/web/assets/javascript/check_opt_params.js
@@ -1,0 +1,17 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const form = document.getElementById('adhoc-jobs-submit-form');
+  form.addEventListener('submit', function (event) {
+    const optionalArgs = document.querySelectorAll('.optional');
+    for (let i = 0; i < optionalArgs.length; i++) {
+      if (optionalArgs[i].value.trim() === '') {
+        for (let j = i + 1; j < optionalArgs.length; j++) {
+          if (optionalArgs[j].value.trim() !== '') {
+            event.preventDefault();
+            alert('You cannot submit the form because an optional parameter is empty, and there are non-empty parameters after it.');
+            return;
+          }
+        }
+      }
+    }
+  });
+});

--- a/lib/sidekiq_adhoc_job/web/assets/javascript/check_opt_params.js
+++ b/lib/sidekiq_adhoc_job/web/assets/javascript/check_opt_params.js
@@ -7,7 +7,7 @@ document.addEventListener("DOMContentLoaded", function () {
         for (let j = i + 1; j < optionalArgs.length; j++) {
           if (optionalArgs[j].value.trim() !== '') {
             event.preventDefault();
-            alert('You cannot submit the form because an optional parameter is empty, and there are non-empty parameters after it.');
+            alert('Please do not leave empty optional parameters when there are non-empty parameters after it');
             return;
           }
         }

--- a/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
+++ b/lib/sidekiq_adhoc_job/web/templates/jobs/show.html.erb
@@ -19,7 +19,7 @@
       <div class="form-group row">
         <label class="col-sm-2 col-form-label" for="<%= arg %>"><%= arg %>:</label>
         <div class="col-sm-4">
-          <input class="form-control" type="text" name="<%= arg %>" id="<%= arg %>"/>
+          <input class="form-control optional" type="text" name="<%= arg %>" id="<%= arg %>"/>
         </div>
       </div>
     <% end %>
@@ -55,6 +55,9 @@
     </div>
   </div>
 </form>
+
+<script type="text/javascript" src="<%= root_path %>javascript/check_opt_params.js">
+</script>
 
 <% if @presented_job.require_confirm %>
   <div id="presented-job" data-confirm-prompt="<%= @presented_job.confirm_prompt_message %>">


### PR DESCRIPTION
# Background 

We have a bug whereby:

Say we have a worker which has three args:

a – required

b – optional, defaults to x

c – optional, defaults to y

When we run the worker in Sidekiq Adhoc Job with b = (empty), and c = <any value>, the value <any value> at c goes to b’s position.

# Design
- Add client side JavaScript to prevent running of job if an argument is empty and there are non-empty args after it.

# Testing
- Ensure alert appears when the situation above arises, preventing running of job.
- Ensure specs pass.