### PR TITLE
Fix crash when worker does not define #perform method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+
+## 2.4.1
+- Fix crash when worker does not define #perform method
+
 ## 2.4.0
 - Switch rspec to test for mutiple sidekiq version
 - Support both sidekiq 8 and 7

--- a/lib/sidekiq_adhoc_job/utils/class_inspector.rb
+++ b/lib/sidekiq_adhoc_job/utils/class_inspector.rb
@@ -48,7 +48,7 @@ module SidekiqAdhocJob
       end
 
       def klass_method(method)
-        return method if method.owner == klass_name
+        return method if method.owner == klass_name || !method.super_method
 
         klass_method(method.super_method)
       end

--- a/lib/sidekiq_adhoc_job/version.rb
+++ b/lib/sidekiq_adhoc_job/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SidekiqAdhocJob
-  VERSION = '2.4.0'
+  VERSION = '2.4.1'
 end

--- a/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
+++ b/spec/sidekiq_adhoc_job/utils/class_inspector_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
 
   describe '#parameters' do
     it do
-      expect(inspector.parameters(:perform)).to eq({
-                                                     key: [:dryrun],
-                                                     keyreq: [:type],
-                                                     opt: %i[retry_job retries interval name options],
-                                                     req: %i[id overwrite]
-                                                   })
+      expect(inspector.parameters(:perform)).to eq(
+        key: [:dryrun],
+        keyreq: [:type],
+        opt: %i[retry_job retries interval name options],
+        req: %i[id overwrite]
+      )
     end
   end
 
@@ -23,10 +23,10 @@ RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
 
     describe '#parameters' do
       it 'returns the parameters of the original method' do
-        expect(inspector.parameters(:perform)).to eq({
-                                                       opt: %i[retry_job retries interval],
-                                                       req: %i[id overwrite]
-                                                     })
+        expect(inspector.parameters(:perform)).to eq(
+          opt: %i[retry_job retries interval],
+          req: %i[id overwrite]
+        )
       end
     end
   end
@@ -36,10 +36,29 @@ RSpec.describe SidekiqAdhocJob::Utils::ClassInspector do
 
     describe '#parameters' do
       it 'returns the parameters of the method on the target class' do
-        expect(inspector.parameters(:perform)).to eq({
-                                                       opt: %i[retry_job retries interval],
-                                                       req: %i[id overwrite]
-                                                     })
+        expect(inspector.parameters(:perform)).to eq(
+          opt: %i[retry_job retries interval],
+          req: %i[id overwrite]
+        )
+      end
+    end
+  end
+
+  context "with an inherited class without redefining method" do
+    before do
+      stub_const("TempWorker", Class.new(SidekiqAdhocJob::Test::DummyWorker))
+    end
+
+    let(:klass) { TempWorker }
+
+    describe "#parameters" do
+      it "returns the parameters of the parent method" do
+        expect(inspector.parameters(:perform)).to eq(
+          key: [:dryrun],
+          keyreq: [:type],
+          opt: [:retry_job, :retries, :interval, :name, :options],
+          req: [:id, :overwrite]
+        )
       end
     end
   end


### PR DESCRIPTION
Cloned from https://github.com/gohkhoonhiang/sidekiq_adhoc_job/pull/38

## Problem

The `/sidekiq_admin/adhoc-jobs/` endpoint will crash if one or more workers do not define `#perform` method. For example:

```ruby

class DummyWorker
  include Sidekiq::Worker

  def perform(id)
  end
end

class DummyWorker2 < DummyWorker
end
```

Can verify in console by:
```ruby
class_inspector = SidekiqAdhocJob::Utils::ClassInspector.new(DummyWorker2)
args = class_inspector.parameters(:perform)
``` 

```
NoMethodError: undefined method 'owner' for nil (NoMethodError)

        return method if method.owner == klass_name
                               ^^^^^^
```

We have to ugly workaround like this:

```ruby
class DummyWorker2 < DummyWorker
  def perform(id)
    super(id)
  end
end
````